### PR TITLE
Fix: Prevent ErrorBoundary crash during server-side rendering

### DIFF
--- a/components/core/ErrorBoundary.tsx
+++ b/components/core/ErrorBoundary.tsx
@@ -49,8 +49,8 @@ export class ErrorBoundary extends Component<Props, State> {
           errorInfo: {
             componentStack: errorInfo.componentStack,
           },
-          userAgent: navigator.userAgent,
-          url: window.location.href,
+          ...(typeof navigator !== "undefined" && { userAgent: navigator.userAgent }),
+          ...(typeof window !== "undefined" && { url: window.location.href }),
           timestamp: new Date().toISOString(),
         },
       })


### PR DESCRIPTION
The ErrorBoundary component was attempting to access `navigator.userAgent` and `window.location.href` unconditionally within its `logErrorToAdmin` method. These browser-specific globals are not available during server-side rendering (e.g., Next.js prerendering), causing an error if the ErrorBoundary was triggered during the build process.

This commit fixes the issue by adding a check for `typeof window !== 'undefined'` before attempting to access these properties. This ensures that browser-specific information is only collected on the client-side, allowing the ErrorBoundary to function correctly in both server and client environments and resolving prerender errors for pages like `/_not-found`.