### PR TITLE
Fix: Various configuration and cleanup updates

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -1,5 +1,5 @@
 {
-  "extends": ["next/core-web-vitals", "prettier"],
+  "extends": ["next/core-web-vitals", "prettier", "eslint-config-prettier"],
   "rules": {
     "prefer-const": "error",
     "no-unused-vars": "error",
@@ -11,6 +11,6 @@
     "react/no-unescaped-entities": "off"
   },
   "parser": "@typescript-eslint/parser",
-  "plugins": ["@typescript-eslint"],
+  "plugins": ["@typescript-eslint", "eslint-plugin-prettier"],
   "ignorePatterns": ["node_modules/", ".next/", "out/", "public/"]
 }

--- a/components/core/Header.tsx
+++ b/components/core/Header.tsx
@@ -6,14 +6,10 @@ import { useAppStore } from "@/lib/store"
 import type { User, UserSettings } from "@/types" // Import types
 import { Button } from "@/components/ui/button"
 import { Badge } from "@/components/ui/badge"
-// SettingsPanel is rendered by TaskDashboard based on store state, so not directly controlled here.
-// import { SettingsPanel } from "@/components/settings/SettingsPanel"
 import Link from "next/link";
 import { Settings, Sparkles, Flame, PlusCircle, Sun, Moon, Trophy, Shield, LogOut } from "lucide-react"; // Add Trophy, Shield, LogOut
 import { DropdownMenu, DropdownMenuContent, DropdownMenuItem, DropdownMenuTrigger, DropdownMenuSeparator, DropdownMenuLabel } from "@/components/ui/dropdown-menu"; // Add DropdownMenu components and Label
 import { Avatar, AvatarFallback, AvatarImage } from "@/components/ui/avatar";
-// Removed: import { useState } from "react"
-// Removed: import { useTheme } from "@/components/theme/theme-provider"
 import { motion } from "framer-motion"
 import { cn } from "@/lib/utils"
 import { useToast } from "@/hooks/use-toast" // For Aura reward notifications

--- a/next.config.mjs
+++ b/next.config.mjs
@@ -14,7 +14,7 @@ const nextConfig = {
     ignoreDuringBuilds: true,
   },
   typescript: {
-    ignoreBuildErrors: true,
+    ignoreBuildErrors: false,
   },
   images: {
     unoptimized: true,

--- a/package.json
+++ b/package.json
@@ -79,6 +79,7 @@
     "three": "latest",
     "use-sync-external-store": "latest",
     "vaul": "^1.1.2",
+    "workbox-webpack-plugin": "^6.6.0",
     "zod": "^3.24.1",
     "zustand": "latest"
   },


### PR DESCRIPTION
This commit addresses several issues to improve project configuration, type safety, and code clarity.

- Updated .eslintrc.json:
    - Added `eslint-plugin-prettier` to the `plugins` array.
    - Added `eslint-config-prettier` to the `extends` array to ensure proper ESLint-Prettier integration.
- Updated TypeScript ignoreBuildErrors settings:
    - Set `ignoreBuildErrors` to `false` in `next.config.mjs` to enforce stricter type checking during production builds.
- Cleaned up redundant imports in `components/core/Header.tsx`:
    - Removed commented-out React imports to improve code clarity.
- Relocated `allowedVideoHostProviders`:
    - Verified that `pnpm.allowedVideoHostProviders` is correctly located in `package.json` and removed it from `pnpm-lock.yaml` (though it was found to be already absent from the lockfile).
- Added Workbox packages to `package.json`:
    - Added `workbox-webpack-plugin` as a direct dependency for better dependency management.
    - Verified no other `workbox-*` packages required direct addition.