### PR TITLE
Fix: Use RPC for atomic API key usage increment

### DIFF
--- a/app/api/process-task/route.ts
+++ b/app/api/process-task/route.ts
@@ -67,10 +67,7 @@ async function processTaskHandler(request: NextRequest) {
         apiKey = adminKeys[0].api_key
 
         // Update usage count
-        await supabase
-          .from("admin_api_keys")
-          .update({ usage_count: supabase.sql`usage_count + 1` })
-          .eq("id", adminKeys[0].id)
+        await supabase.rpc('increment_api_key_usage', { p_key_id: adminKeys[0].id })
       }
     }
 

--- a/lib/get-api-key.ts
+++ b/lib/get-api-key.ts
@@ -24,11 +24,9 @@ export async function getApiKeyForUser(userId: string): Promise<string | null> {
 
   if (adminKeys && adminKeys.length > 0) {
     const adminKey = adminKeys[0];
-    // Update usage count (fire and forget)
+    // Update usage count using RPC (fire and forget)
     supabase
-      .from("admin_api_keys")
-      .update({ usage_count: supabase.sql`usage_count + 1` })
-      .eq("id", adminKey.id)
+      .rpc('increment_api_key_usage', { p_key_id: adminKey.id })
       .then(({ error }) => {
         if (error) console.error("Error updating admin key usage:", error);
       });

--- a/supabase/schema.sql
+++ b/supabase/schema.sql
@@ -262,6 +262,16 @@ BEGIN
 END;
 $$ LANGUAGE plpgsql SECURITY DEFINER;
 
+-- FUNCTION: increment_api_key_usage
+CREATE OR REPLACE FUNCTION public.increment_api_key_usage(p_key_id uuid)
+RETURNS void AS $$
+BEGIN
+    UPDATE public.admin_api_keys
+    SET usage_count = usage_count + 1
+    WHERE id = p_key_id;
+END;
+$$ LANGUAGE plpgsql SECURITY DEFINER;
+
 -- FUNCTION: check_and_award_achievements()
 CREATE OR REPLACE FUNCTION public.check_and_award_achievements(p_user_id uuid)
 RETURNS void AS $$


### PR DESCRIPTION
Replaced direct table updates with an RPC call to a new database function `increment_api_key_usage`.

This resolves a TypeError (`Property 'sql' does not exist on type 'SupabaseClient'`) that occurred during the build process. Using an RPC function ensures atomic and safe increments of the `usage_count` in the `admin_api_keys` table, preventing potential race conditions and aligning with Supabase best practices.

Changes were made in:
- `supabase/schema.sql`: Added the `increment_api_key_usage` function.
- `app/api/process-task/route.ts`: Updated to call the RPC function.
- `lib/get-api-key.ts`: Updated to call the RPC function.