### PR TITLE
Fix: Specify type for 'st' parameter in process-task API

### DIFF
--- a/app/api/process-task/route.ts
+++ b/app/api/process-task/route.ts
@@ -291,7 +291,7 @@ ${
             }
 
             // Validate sub_tasks
-            if (!Array.isArray(parsedAnalysis.sub_tasks) || !parsedAnalysis.sub_tasks.every(st => typeof st === "string")) {
+            if (!Array.isArray(parsedAnalysis.sub_tasks) || !parsedAnalysis.sub_tasks.every((st: string) => typeof st === "string")) {
               await supabase.rpc("log_event", {
                 p_level: "WARNING",
                 p_message: "AI response validation failed for sub_tasks structure or type",


### PR DESCRIPTION
The 'st' parameter in the Array.every() callback function within app/api/process-task/route.ts was implicitly typed as 'any'. This change explicitly types 'st' as 'string', resolving the TypeScript build error.