### PR TITLE
Fix: Resolve TypeScript type error in process-task API

### DIFF
--- a/app/api/process-task/route.ts
+++ b/app/api/process-task/route.ts
@@ -91,7 +91,7 @@ async function processTaskHandler(request: NextRequest) {
     }
 
     // Prepare AI analysis based on user preferences
-    let aiAnalysis = {
+    let aiAnalysis: AiAnalysisState = {
       ai_speed_score: null,
       ai_importance_score: null,
       speed_tag: null,
@@ -344,6 +344,16 @@ ${
               ...parsedAnalysis,
               ai_generated: true,
             }
+
+interface AiAnalysisState {
+  ai_speed_score: number | null;
+  ai_importance_score: number | null;
+  speed_tag: string | null;
+  importance_tag: string | null;
+  emoji: string | null;
+  sub_tasks: string[];
+  ai_generated: boolean;
+}
 
             // Log successful AI processing
             await supabase.rpc("log_event", {


### PR DESCRIPTION
The `aiAnalysis` variable was initially inferred with types that were too restrictive for subsequent assignments involving `parsedAnalysis`. This led to a type error when attempting to spread `parsedAnalysis` into `aiAnalysis`.

This commit introduces a new interface, `AiAnalysisState`, which accurately defines the complete set of properties and their possible types for the `aiAnalysis` object throughout its lifecycle. The `aiAnalysis` variable is now explicitly typed with `AiAnalysisState`.

This change ensures that the types for properties like `ai_speed_score`, `ai_importance_score`, `speed_tag`, `importance_tag`, `emoji`, and `sub_tasks` are compatible during the spread operation, resolving the TypeScript build error.