### PR TITLE
Fix: Add missing type definitions for 'three'

### DIFF
--- a/package.json
+++ b/package.json
@@ -89,6 +89,7 @@
     "@types/node": "^22.15.31",
     "@types/react": "^19.1.8",
     "@types/react-dom": "^19.1.6",
+    "@types/three": "^0.177.0",
     "@typescript-eslint/eslint-plugin": "^8.34.0",
     "@typescript-eslint/parser": "^8.34.0",
     "eslint": "^9.28.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -240,6 +240,9 @@ importers:
       '@types/react-dom':
         specifier: ^19.1.6
         version: 19.1.6(@types/react@19.1.8)
+      '@types/three':
+        specifier: ^0.177.0
+        version: 0.177.0
       '@typescript-eslint/eslint-plugin':
         specifier: ^8.34.0
         version: 8.34.0(@typescript-eslint/parser@8.34.0(eslint@9.28.0(jiti@1.21.7))(typescript@5.8.3))(eslint@9.28.0(jiti@1.21.7))(typescript@5.8.3)


### PR DESCRIPTION
The project was failing to compile due to a TypeScript error indicating that type declarations for the 'three' library were not found. This resulted in 'three' being implicitly typed as 'any'.

This commit resolves the issue by adding '@types/three' as a dev dependency, which provides the necessary type definitions for the 'three' library. This allows TypeScript to correctly type-check code importing from 'three' and resolves the compilation error.